### PR TITLE
Fix bug causing 'Adjust the build platform position' to come up twice.

### DIFF
--- a/src/preparetab.cpp
+++ b/src/preparetab.cpp
@@ -273,6 +273,8 @@ void PrepareTab::svgRenderer_done( int const totalLayers ) {
 void PrepareTab::_prepareButton_clicked( bool ) {
     debug( "+ PrepareTab::_prepareButton_clicked\n" );
 
+    QObject::disconnect( _prepareButton, nullptr, this, nullptr );
+
     _prepareMessage->setText( QString( "Moving the printer to its home location..." ) );
     _prepareProgress->show( );
 


### PR DESCRIPTION
The first button click event handler wasn't being disconnected from the button before the second was added, so the first time the "Continue" button was clicked, both steps were repeated.